### PR TITLE
Fix suid

### DIFF
--- a/dojjail/ns.py
+++ b/dojjail/ns.py
@@ -11,6 +11,8 @@ from .utils import fork_clean
 libc = ctypes.CDLL("libc.so.6")
 
 
+PR_SET_DUMPABLE   = 4
+
 class NS(enum.IntFlag):
     USER   = 0x10000000
     MOUNT  = 0x00020000
@@ -30,6 +32,8 @@ def new_ns(ns_flags=NS.ALL, uid_map=None):
 
     unshared_event = multiprocessing.Event()
     uid_mapped_event = multiprocessing.Event()
+
+    libc.prctl(PR_SET_DUMPABLE, True)
 
     pid = fork_clean()
 


### PR DESCRIPTION
Without this, dojjail `Host.exec` fails with:
```
  File "/usr/local/lib/python3.8/dist-packages/dojjail/host.py", line 183, in exec
    self.enter(uid=uid)
  File "/usr/local/lib/python3.8/dist-packages/dojjail/host.py", line 160, in enter
    set_ns(self.pid, self.ns_flags)
  File "/usr/local/lib/python3.8/dist-packages/dojjail/ns.py", line 72, in set_ns
    assert libc.setns(os.open(ns_path, 0), 0) == 0, ns_path
PermissionError: [Errno 13] Permission denied
```

It fails to open the namespace path. With this change, it works. This specifically occurs when run suid (e.g. `sudo ...` works fine).

I'm not totally convinced about this fix, it seems like we should be able to `PR_SET_DUMPABLE` ourselves outside of dojjail, but for some reason that was not working while testing. There is also some non-zero chance that this could be dangerous for our security.

As for why?

```
A task that changes one of its effective IDs will have its
       dumpability reset to the value in /proc/sys/fs/suid_dumpable.
       This may affect the ownership of proc files of child processes
       and may thus cause the parent to lack the permissions to write to
       mapping files of child processes running in a new user namespace.
       In such cases making the parent process dumpable, using
       PR_SET_DUMPABLE in a call to [prctl(2)](https://man7.org/linux/man-pages/man2/prctl.2.html), before creating a child
       process in a new user namespace may rectify this problem.  See
       [prctl(2)](https://man7.org/linux/man-pages/man2/prctl.2.html) and [proc(5)](https://man7.org/linux/man-pages/man5/proc.5.html) for details on how ownership is affected.
```

Probably that is related (https://man7.org/linux/man-pages/man7/user_namespaces.7.html).

I need to investigate this further. I pulled this fix from Intercepting Communications, but I don't totally remember the full line-of-reasoning.