### PR TITLE
Fix Host cleanup to avoid kill(0) and track target PID correctly

### DIFF
--- a/dojjail/host.py
+++ b/dojjail/host.py
@@ -141,7 +141,7 @@ class Host:
 
     def kill(self, *, signal=signal.SIGTERM):
         # This SIGTERM goes to the "waiting python process".
-        if self.pid > 1:
+        if self.pid > 0:
             try:
                 os.kill(self.pid, signal)
             except ProcessLookupError:
@@ -149,7 +149,7 @@ class Host:
 
         # Only kill the target PID when we actually created one.
         target_pid = host_target_pids[self.id].value
-        if self.ns_flags & NS.PID and target_pid > 1:
+        if self.ns_flags & NS.PID and target_pid > 0:
             try:
                 os.kill(target_pid, 9)
             except ProcessLookupError:

--- a/dojjail/host.py
+++ b/dojjail/host.py
@@ -99,7 +99,7 @@ class Host:
             socket.sethostname(self.name)
         if self.ns_flags & NS.PID:
             pid = fork_clean(parent_death_signal=None if self.persist else 9)
-            host_target_pids[self.id] = pid
+            host_target_pids[self.id].value = pid
             if pid:
                 with DelayedKeyboardInterrupt():
                     os.waitid(os.P_PID, pid, os.WEXITED)
@@ -140,13 +140,20 @@ class Host:
         return result
 
     def kill(self, *, signal=signal.SIGTERM):
-        try:
-            # This SIGTERM goes to the "waiting python process"
-            os.kill(self.pid, signal)
-            # Target being executed in namespaces does not exit gracefully /w SIGTERM
-            os.kill(host_target_pids[self.id].value, 9)
-        except ProcessLookupError:
-            pass
+        # This SIGTERM goes to the "waiting python process".
+        if self.pid > 1:
+            try:
+                os.kill(self.pid, signal)
+            except ProcessLookupError:
+                pass
+
+        # Only kill the target PID when we actually created one.
+        target_pid = host_target_pids[self.id].value
+        if self.ns_flags & NS.PID and target_pid > 1:
+            try:
+                os.kill(target_pid, 9)
+            except ProcessLookupError:
+                pass
 
     def enter(self, *, uid=PRIVILEGED_UID):
         assert self.pid


### PR DESCRIPTION
Summary
- store child PID in shared host_target_pids via .value instead of overwriting the Value wrapper
- guard cleanup signals so we only signal valid PIDs (> 1)
- only send the hard-kill to host_target_pids when NS.PID is enabled

Why
Network hosts can run without NS.PID, leaving host_target_pids[...] at 0. The prior unconditional os.kill(host_target_pids[..].value, 9) can become kill(0, SIGKILL), which kills the current process group and can tear down the whole container under kata.

This change keeps cleanup behavior for PID-namespace hosts but prevents accidental process-group kills.
